### PR TITLE
Push to ECR

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REPO=public.ecr.aws/layerai/executor

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
+      BUILDKIT_INLINE_CACHE: 1
     steps:
       - uses: jlumbroso/free-disk-space@main
         with:
@@ -34,6 +35,20 @@ jobs:
           poetry-version: 1.2.0
       - name: Integration test
         run: make integration-test
+      - name: Configure AWS Credentials
+        if: github.ref_name == 'main'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Login to Amazon ECR
+        if: github.ref_name == 'main'
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
       - name: Push
         if: github.ref_name == 'main'
-        run: make push
+        run: REPO=public.ecr.aws/t4m4i2i6/executor make push
+

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,5 @@ build:
 .PHONY: push
 push: build
 	TAG_SUFFIX=${TAG_SUFFIX} docker compose push ${TARGET}
+	TAG_SUFFIX=${PUSH_OVERWRITE_SUFFIX} docker compose build ${TARGET}
 	TAG_SUFFIX=${PUSH_OVERWRITE_SUFFIX} docker compose push ${TARGET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: ./
       dockerfile: docker/Dockerfile
+      cache_from:
+        - ${REPO}:python3.7
       args:
         - PYTHON_VERSION=3.7.13
         - PIP_VERSION=22.2.2
@@ -15,6 +17,8 @@ services:
     build:
       context: ./
       dockerfile: docker/Dockerfile
+      cache_from:
+        - ${REPO}:python3.8
       args:
         - PYTHON_VERSION=3.8.13
         - PIP_VERSION=22.2.2
@@ -24,9 +28,13 @@ services:
     build:
       context: ./
       dockerfile: docker/python3.7-gpu.Dockerfile
+      cache_from:
+        - ${REPO}:python3.7-gpu
 
   python3.8-gpu:
     image: ${REPO}:python3.8-gpu${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: docker/python3.8-gpu.Dockerfile
+      cache_from:
+        - ${REPO}:python3.8-gpu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   python3.7:
-    image: public.ecr.aws/layerai/executor:python3.7${TAG_SUFFIX:-}
+    image: ${REPO}:python3.7${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: docker/Dockerfile
@@ -11,7 +11,7 @@ services:
         - PIP_VERSION=22.2.2
 
   python3.8:
-    image: public.ecr.aws/layerai/executor:python3.8${TAG_SUFFIX:-}
+    image: ${REPO}:python3.8${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: docker/Dockerfile
@@ -20,13 +20,13 @@ services:
         - PIP_VERSION=22.2.2
 
   python3.7-gpu:
-    image: public.ecr.aws/layerai/executor:python3.7-gpu${TAG_SUFFIX:-}
+    image: ${REPO}:python3.7-gpu${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: docker/python3.7-gpu.Dockerfile
 
   python3.8-gpu:
-    image: public.ecr.aws/layerai/executor:python3.8-gpu${TAG_SUFFIX:-}
+    image: ${REPO}:python3.8-gpu${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: docker/python3.8-gpu.Dockerfile


### PR DESCRIPTION
Our ECR public alias is in the process of approval so using the default one - `public.ecr.aws/t4m4i2i6/executor`. Once it is life, they can be used interchangeably.