### PR TITLE
Fix python version tests

### DIFF
--- a/test/test_images.py
+++ b/test/test_images.py
@@ -61,17 +61,17 @@ def test_layer_import(tag, get_full_image_name):
     zip(
         EXECUTOR_TAGS,
         [
-            b"Python 3.7.13\n",
-            b"Python 3.8.13\n",
-            b"Python 3.7.13\n",
-            b"Python 3.8.10\n",
+            b"3.7\n",
+            b"3.8\n",
+            b"3.7\n",
+            b"3.8\n",
         ],
     ),
 )
 def test_python_version(tag, output, get_full_image_name):
     with _run_container(
         image=get_full_image_name(tag),
-        command="--version",
+        command="-c 'import sys; print(f\"{sys.version_info[0]}.{sys.version_info[1]}\")'",
         entrypoint=_get_python_path_from_tag(tag),
     ) as container:
         assert _wait_for_container(container) == {"Error": None, "StatusCode": 0}


### PR DESCRIPTION
The gpu images don't pin the patch version which means that when there is a patch update, the tests fail. Switch the tests to only check the major and minor version of Python but not the patch version.

Q: Do we want to pin the patch version in the GPU images or unpin it in the CPU ones? Currently they are inconsistent.